### PR TITLE
Add driver csv export and test ride export

### DIFF
--- a/server/api/reports.php
+++ b/server/api/reports.php
@@ -1,0 +1,119 @@
+<?php
+
+include '../env.php';
+require_once "../db.class.php";
+$db = new DB($host, $port, $name, $user, $pass); // From dbinfo.php
+$delimiter = ",";
+
+if ($_SERVER['REQUEST_METHOD'] === 'GET')
+{
+   if (isset($_GET['info']))
+   {
+      if ($_GET['info'] == 'ride')
+      {
+         exportRideToCSV();
+      }
+      else if ($_GET['info'] == 'driver')
+      {
+         exportDriverToCSV();
+      }
+   }
+}
+
+function exportDriverToCSV($filename = "drivers.csv")
+{
+   header('Content-Type: application/csv; charset=UTF-8');
+   header('Content-Disposition: attachment; filename="' .$filename .'";');
+   global $db;
+   global $delimiter;
+
+   $columnNames = array("First Name", "Last Name", "Phone", "Email Address", "Wants Email", "Wants SMS", "Driver Schedule Monday",
+      "Driver Schedule Tuesday", "Driver Schedule Wednesday", "Driver Schedule Thursday", "Driver Schedule Friday",
+      "Driver Schedule Saturday", "Driver Schedule Sunday");
+   $data = $db->user->getDriverExportInfo();
+
+   $f = fopen('php://output', 'w');
+   fputcsv($f, $columnNames, $delimiter);
+   fputcsv($f, array());
+   $lastDriverID = -1;
+   $lastDriver = null;
+
+   foreach ($data as $driver)
+   {
+      if ($lastDriverID == -1)
+      {
+         $lastDriverID = $driver['id'];
+         $lastDriver = $driver;
+      }
+
+      if ($driver['id'] != $lastDriverID)
+      {
+         unset($lastDriver['id']);
+         unset($lastDriver['start']);
+         unset($lastDriver['end']);
+         unset($lastDriver['days']);
+         $lastDriver['wantsSMS'] = $lastDriver['wantsSMS'] == 1 ? "Yes" : "No";
+         $lastDriver['wantsEmail'] = $lastDriver['wantsEmail'] == 1 ? "Yes" : "No";
+         fputcsv($f, $lastDriver, $delimiter);
+
+         $lastDriver = $driver;
+         $lastDriverID = $driver['id'];
+      }
+
+      AddDriverSchedule($driver, $lastDriver);
+   }
+
+   fpassthru($f);
+   fclose($f);
+}
+
+function exportRideToCSV($filename = "event_appointments.csv")
+{
+   header('Content-Type: application/csv; charset=UTF-8');
+   header('Content-Disposition: attachment; filename="' .$filename .'";');
+   global $db;
+   global $delimiter;
+
+   $columnNames = $db->ride->getRideColumnNames();
+   /*$columnNames = array("Trip Date", "Trip Day", "Appt Time", "First Name", "Last Name", "Street Address, Town, Zip Code",
+      "Phone with Area Code (xxx-xxx-xxxx", "Email Address", "Destination Street Address, Town, Zip Code", "Driver Name",
+      "Medical Motors Wheelchair Van (yes or no)", "Driver - Notes", "Client - Notes", "Appointment Status",
+      "Appointment - Total Miles", "Appointment - Total Hours");*/
+   $data = $db->ride->getRides();
+   $f = fopen('php://output', 'w');
+
+   fputcsv($f, $columnNames, $delimiter);
+   foreach ($data as $line)
+   {
+      fputcsv($f, $line, $delimiter);
+   }
+
+   fpassthru($f);
+   fclose($f);
+}
+
+function AddDriverSchedule($driver, &$lastDriver)
+{
+   AddDriverDailySchedule($driver, $lastDriver, "mon");
+   AddDriverDailySchedule($driver, $lastDriver, "tue");
+   AddDriverDailySchedule($driver, $lastDriver, "wed");
+   AddDriverDailySchedule($driver, $lastDriver, "thu");
+   AddDriverDailySchedule($driver, $lastDriver, "fri");
+   AddDriverDailySchedule($driver, $lastDriver, "sat");
+   AddDriverDailySchedule($driver, $lastDriver, "sun");
+}
+
+function AddDriverDailySchedule($driver, &$lastDriver, $day)
+{
+   if (stripos($driver['days'], $day) !== false)
+   {
+      if (isset($lastDriver[$day]))
+      {
+         $lastDriver[$day] .= ", " .$driver['start'] ." - " .$driver['end'];
+      }
+      else
+      {
+         $lastDriver[$day] = $driver['start'] ." - " .$driver['end'];
+      }
+   }
+}

--- a/server/dao/RideDAO.php
+++ b/server/dao/RideDAO.php
@@ -32,7 +32,7 @@ class RideDAO
         }
     }
 
-    public function getRides($page = 0, $numberPerPage = 10, $populate)
+    public function getRides($page = 0, $numberPerPage = 10, $populate = false)
     {
         try {
             $stmt = $this->dbh->prepare("SELECT * FROM ride LIMIT :lim OFFSET :offset");
@@ -57,6 +57,27 @@ class RideDAO
             echo $e->getMessage();
             die();
         }
+    }
+
+    public function getRideColumnNames()
+    {
+       try
+       {
+          $stmt = $this->dbh->prepare("SHOW columns FROM ride");
+          $stmt->execute();
+
+          while ($row = $stmt->fetch())
+          {
+             $data[] = $row['Field'];
+          }
+
+          return $data;
+       }
+       catch (PDOException $e)
+       {
+          echo $e->getMessage();
+          die();
+       }
     }
 
     public function insertRide(

--- a/server/dao/UserDAO.php
+++ b/server/dao/UserDAO.php
@@ -61,6 +61,31 @@ class UserDAO {
         }
     }
 
+   public function getDriverExportInfo()
+   {
+      try
+      {
+         $query = "SELECT user.id, firstName, lastName, phone, email, wantsSMS, wantsEmail, start, end, days FROM user
+                      LEFT JOIN availability ON (user.id = availability.driverID)
+                      WHERE role = 'driver'";
+         $stmt = $this->dbh->prepare($query);
+         $stmt->execute();
+         $stmt->setFetchMode(PDO::FETCH_ASSOC);
+
+         while ($row = $stmt->fetch())
+         {
+            $data[] = $row;
+         }
+
+         return $data;
+      }
+      catch (PDOException $e)
+      {
+         echo $e->getMessage();
+         die();
+      }
+   }
+
     function insertUser($password, $role, $firstName, $lastName, $phone, $email, $registered, $lastLogin = "",
                         $wantsSMS = true, $wantsEmail = true)
     {


### PR DESCRIPTION
I've done the Driver Information CSV they have. There's also export of the Ride table just so we could have 2 different things for now. Since there's some post-processing to get the CSVs as close as possible to what they have it probably won't be all done before you record the presentation videos so at least you have 2 different CSVs with this.

@mxs4321 What's the final decision for the the rest of the CSVs? Are you going to ask them if we should stick with their layout (since for example we don't have anything from the Destination Information other than the address in a single field)? Just so I don't do unnecessary work if it's still going to be discussed with the sponsors.

Everything is at the reports.php endpoint with "info" parameter changing which report you want.